### PR TITLE
Fix CSS shorthand order

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -221,8 +221,8 @@ static void attach_config_colors_to_screen(Config *config)
             "box-shadow: none;\n"
             "border-image-width: 0;\n"
         "}\n"
-        , config->font
         , config->font_size
+        , config->font
         , gdk_rgba_to_string(config->text_color)
         , gdk_rgba_to_string(config->error_color)
         , gdk_rgba_to_string(config->background_color)


### PR DESCRIPTION
Hey there! Just noticed that the shorthand order for fonts was permuted, so that was breaking font sizes with units.

https://developer.gnome.org/gtk3/stable/chap-css-properties.html#id-1.5.3.3.15